### PR TITLE
Refactor EditorBottombarButton to ToggleButton

### DIFF
--- a/apps/app/components/editorBottombar/EditorBottombar.tsx
+++ b/apps/app/components/editorBottombar/EditorBottombar.tsx
@@ -34,7 +34,7 @@ export const EditorBottombar = forwardRef(
     return (
       <ScrollView
         horizontal={true}
-        style={[tw`h-${editorBottombarHeight / 4} border-t border-gray-200`]}
+        style={[tw`h-${editorBottombarHeight / 4} border-t border-gray-300`]}
         contentContainerStyle={tw`px-2.5`} // needed here as it isn't handled correctly on the parent element
         ref={ref}
       >

--- a/apps/app/components/page/PageHeader.tsx
+++ b/apps/app/components/page/PageHeader.tsx
@@ -1,6 +1,6 @@
 import {
-  IconButton,
   Text,
+  ToggleButton,
   Tooltip,
   useIsDesktopDevice,
 } from "@serenity-tools/ui";
@@ -26,12 +26,11 @@ export const PageHeader: React.FC<Props> = ({ toggleCommentsDrawer }) => {
       ) : null}
       {isDesktopDevice ? (
         <Tooltip label="Toggle Comments" placement="left" offset={8}>
-          <IconButton
+          <ToggleButton
             onPress={() => {
               toggleCommentsDrawer();
             }}
             name="chat-4-line"
-            color={"gray-800"}
             size={"lg"}
           />
         </Tooltip>

--- a/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
+++ b/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
@@ -43,6 +43,7 @@ import {
   Spinner,
   Text,
   TextArea,
+  ToggleButton,
   Tooltip,
   tw,
   useIsDesktopDevice,
@@ -134,6 +135,9 @@ export default function DesignSystemScreen(
 
   // for Select
   const [userRole, setUserRole] = React.useState("");
+
+  // for Toggle
+  const [isActive, setIsActive] = React.useState<boolean>(false);
 
   return (
     <ScrollSafeAreaView>
@@ -420,7 +424,7 @@ export default function DesignSystemScreen(
           The default is medium, to make it a bit bigger use the{" "}
           <DSMono variant="property">lg</DSMono> property.
         </Text>
-        <Text variant="sm" style={tw`mt-4`}>
+        <Text variant="sm" style={tw`mt-1`}>
           For special cases such as the navigation-bar, which one should be able
           to use with one hand, we use the{" "}
           <DSMono variant="property">xl</DSMono> version for mobile to increase
@@ -1121,7 +1125,7 @@ export default function DesignSystemScreen(
           Icons don't have a style property, but you can still dye them with the{" "}
           <DSMono variant="property">color</DSMono> property.
         </Text>
-        <Text variant="sm" style={tw`mt-4`}>
+        <Text variant="sm" style={tw`mt-1`}>
           You can use all of our custom colors defined for the application by
           typing the name and if necessary the hue value:{" "}
           <DSMono variant="type">collaboration-honey</DSMono>,{" "}
@@ -1446,7 +1450,7 @@ export default function DesignSystemScreen(
           <DSMono variant="type">font-family</DSMono> as well as when said
           parent is set to <DSMono variant="property">bold</DSMono>.
         </Text>
-        <Text variant="sm" style={tw`mt-2`}>
+        <Text variant="sm" style={tw`mt-1`}>
           Be aware that the color stays the same no matter if the parent{" "}
           <DSMono variant="component">Text</DSMono> is set to be{" "}
           <DSMono variant="property">muted</DSMono> or the color is changed, to
@@ -1480,7 +1484,7 @@ export default function DesignSystemScreen(
           <DSMono variant="property">quiet</DSMono> property to avoid the
           primary-color override.
         </Text>
-        <Text variant="sm" style={tw`mt-2`}>
+        <Text variant="sm" style={tw`mt-1`}>
           Notice though you will need to set both the{" "}
           <DSMono variant="property">variant</DSMono> and if need be the{" "}
           <DSMono variant="property">muted</DSMono> properties to match the{" "}
@@ -1623,7 +1627,7 @@ export default function DesignSystemScreen(
           for the user to understand and learn the common actions of the
           application.
         </Text>
-        <Text variant="sm" style={tw`mt-2`}>
+        <Text variant="sm" style={tw`mt-1`}>
           Add the optional property <DSMono variant="property">danger</DSMono>{" "}
           to show the user irreversible actions.
         </Text>
@@ -1706,7 +1710,7 @@ export default function DesignSystemScreen(
           <DSMono variant="component">Shortcut</DSMono> component via{" "}
           <DSMono variant="property">shortcut</DSMono> .
         </Text>
-        <Text variant="sm" style={tw`mt-2 text-left`}>
+        <Text variant="sm" style={tw`mt-1 text-left`}>
           To avoid accidents don't put a shortcut on a{" "}
           <DSMono variant="context">dangerous</DSMono> action.
         </Text>
@@ -1789,7 +1793,7 @@ export default function DesignSystemScreen(
           the
           <DSMono variant="component">ModalButtonFooter</DSMono> component.
         </Text>
-        <Text variant="sm" style={tw`mt-2`}>
+        <Text variant="sm" style={tw`mt-1`}>
           This component requires to be passed a{" "}
           <DSMono variant="component">Button</DSMono> via the Footers{" "}
           <DSMono variant="property">confirm</DSMono> property. To add a{" "}
@@ -2233,6 +2237,49 @@ export default function DesignSystemScreen(
             This will fail
           </Button>
         </DSExampleArea>
+
+        <Heading lvl={1}>ToggleButton</Heading>
+        <Text>
+          The{" "}
+          <DSMono variant="component" size="md">
+            ToggleButton
+          </DSMono>{" "}
+          is used to switch between two options and the result of the change is
+          immediate.
+        </Text>
+        <Heading lvl={3}>Basic</Heading>
+        <Text variant="sm">
+          A <DSMono variant="component">ToggleButton</DSMono> has the usual
+          properties of a simple icon-button wihout color variants.
+        </Text>
+        <DSExampleArea>
+          <ToggleButton
+            name="chat-4-line"
+            isActive={isActive}
+            onPress={() => setIsActive((prevIsActive) => !prevIsActive)}
+          />
+          <ToggleButton name="chat-4-line" disabled />
+        </DSExampleArea>
+        <Heading lvl={3}>Size</Heading>
+        <Text variant="sm">
+          It comes in 2 predefined sizes <DSMono variant="type">md</DSMono> and{" "}
+          <DSMono variant="type">lg</DSMono>.
+        </Text>
+        <Text variant="sm" style={tw`mt-1`}>
+          One can use different proportions by adding height and width-classes
+          via the <DSMono variant="property">style</DSMono> property.
+        </Text>
+        <DSExampleArea>
+          <ToggleButton name="chat-4-line" />
+          <ToggleButton size="lg" name="chat-4-line" />
+          <ToggleButton size="lg" name="chat-4-line" style={tw`h-7 w-8.5`} />
+          <ToggleButton size="lg" name="chat-4-line" style={tw`h-10 w-10`} />
+        </DSExampleArea>
+        <Text variant="xxs" style={tw`mt-4`} muted>
+          Notice though that the Icon will stay the same size as we should only
+          use the custom-sizing for very special cases if it improves the
+          usability like in the EditorBottombar on mobile.
+        </Text>
 
         <Heading lvl={1}>Tooltip</Heading>
         <Text>

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -1,6 +1,5 @@
 import {
   BoxShadow,
-  EditorBottombarButton,
   EditorBottombarDivider,
   RawInput,
   SubmitButton,
@@ -8,6 +7,7 @@ import {
   tw,
   useHasEditorSidebar,
   View,
+  ToggleButton,
 } from "@serenity-tools/ui";
 import { EditorEvents, isTextSelection } from "@tiptap/core";
 import Collaboration from "@tiptap/extension-collaboration";
@@ -295,19 +295,19 @@ export const Editor = (props: EditorProps) => {
                 style={tw`p-1 bg-white border border-gray-200 rounded`}
                 alignItems="center"
               >
-                <EditorBottombarButton
+                <ToggleButton
                   onPress={() => editor.chain().focus().toggleBold().run()}
                   name="bold"
                   isActive={editor.isActive("bold")}
                 />
 
-                <EditorBottombarButton
+                <ToggleButton
                   onPress={() => editor.chain().focus().toggleItalic().run()}
                   name="italic"
                   isActive={editor.isActive("italic")}
                 />
 
-                <EditorBottombarButton
+                <ToggleButton
                   onPress={() => editor.chain().focus().toggleCode().run()}
                   name="code-view"
                   isActive={editor.isActive("code")}
@@ -315,7 +315,7 @@ export const Editor = (props: EditorProps) => {
 
                 <EditorBottombarDivider />
 
-                <EditorBottombarButton
+                <ToggleButton
                   onPress={() =>
                     editor.chain().focus().toggleLink({ href: "#" }).run()
                   }
@@ -325,7 +325,7 @@ export const Editor = (props: EditorProps) => {
 
                 <EditorBottombarDivider />
 
-                <EditorBottombarButton
+                <ToggleButton
                   onPress={() => {
                     setHasCreateCommentBubble(true);
                   }}

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -313,8 +313,7 @@ export const Editor = (props: EditorProps) => {
                   isActive={editor.isActive("code")}
                 />
 
-                {/* for some reason tailwind md:h-6 doesn't work on the Divider yet */}
-                <EditorBottombarDivider style={tw`h-6`} />
+                <EditorBottombarDivider />
 
                 <EditorBottombarButton
                   onPress={() =>
@@ -324,8 +323,7 @@ export const Editor = (props: EditorProps) => {
                   isActive={editor.isActive("link")}
                 />
 
-                {/* for some reason tailwind md:h-6 doesn't work on the Divider yet */}
-                <EditorBottombarDivider style={tw`h-6`} />
+                <EditorBottombarDivider />
 
                 <EditorBottombarButton
                   onPress={() => {

--- a/packages/ui/components/editorBottombarButton/EditorBottombarButton.tsx
+++ b/packages/ui/components/editorBottombarButton/EditorBottombarButton.tsx
@@ -1,64 +1,11 @@
-import { useFocusRing } from "@react-native-aria/focus";
-import { HStack } from "native-base";
 import React, { forwardRef } from "react";
-import { Platform, StyleSheet } from "react-native";
 import { tw } from "../../tailwind";
-import { Icon, IconNames } from "../icon/Icon";
-import { Pressable, PressableProps } from "../pressable/Pressable";
+import { ToggleButton, ToggleButtonProps } from "../toggleButton/ToggleButton";
 
-export type EditorBottombarButtonProps = PressableProps & {
-  name: IconNames;
-  isActive?: boolean;
-};
+export type EditorBottombarButtonProps = ToggleButtonProps & {};
 
 export const EditorBottombarButton = forwardRef(
   (props: EditorBottombarButtonProps, ref) => {
-    const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
-    const { name, isActive, ...rest } = props;
-
-    const styles = StyleSheet.create({
-      pressable: tw``,
-      hstack: tw`h-7 w-8.5 md:h-6 md:w-6 items-center justify-center bg-transparent rounded`,
-      active: tw`bg-primary-100`,
-      hover: isActive ? tw`bg-primary-200` : tw`bg-gray-200`,
-      pressed: tw`bg-primary-200`,
-      focusVisible: Platform.OS === "web" ? tw`se-inset-focus-mini` : {},
-      disabled: tw`bg-transparent opacity-50`, // TODO opacity tbd
-    });
-
-    return (
-      <Pressable
-        ref={ref}
-        {...rest}
-        accessibilityRole={props.accessibilityRole ?? "button"}
-        // @ts-expect-error - web only
-        onFocus={focusRingProps.onFocus}
-        // @ts-expect-error - web only
-        onBlur={focusRingProps.onBlur}
-        // disable default outline styles
-        // @ts-expect-error - web only
-        _focusVisible={{ _web: { style: { outlineStyle: "none" } } }}
-        style={(styles.pressable, props.style)}
-      >
-        {({ isPressed, isHovered, isFocused }) => {
-          return (
-            <HStack
-              style={[
-                styles.hstack,
-                isActive && styles.active,
-                isHovered && styles.hover,
-                isPressed && styles.pressed,
-                isFocusVisible && styles.focusVisible,
-              ]}
-            >
-              <Icon
-                name={name}
-                color={isActive || isPressed ? "primary-500" : "gray-800"}
-              />
-            </HStack>
-          );
-        }}
-      </Pressable>
-    );
+    return <ToggleButton {...props} style={tw`h-7 w-8.5`} />;
   }
 );

--- a/packages/ui/components/editorBottombarDivider/EditorBottombarDivider.tsx
+++ b/packages/ui/components/editorBottombarDivider/EditorBottombarDivider.tsx
@@ -7,8 +7,7 @@ export type EditorBottombarDividerProps = RNView["props"] & {
 };
 
 const styles = StyleSheet.create({
-  // TODO make tailwind md:h-6 work here
-  default: tw`h-8 md:h-6 mx-0.5 border-r border-gray-200`,
+  default: tw`h-6 mx-0.5 border-r border-gray-300`,
   collapsed: tw`mx-0`,
 });
 

--- a/packages/ui/components/toggleButton/ToggleButton.tsx
+++ b/packages/ui/components/toggleButton/ToggleButton.tsx
@@ -14,7 +14,7 @@ export type ToggleButtonProps = PressableProps & {
 
 export const ToggleButton = forwardRef((props: ToggleButtonProps, ref) => {
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
-  const { name, isActive, size = "md", ...rest } = props;
+  const { name, isActive, size = "md", disabled, ...rest } = props;
 
   const dimensions = size === "md" ? "h-6 w-6" : "h-8 w-8";
 
@@ -56,6 +56,8 @@ export const ToggleButton = forwardRef((props: ToggleButtonProps, ref) => {
               isHovered && styles.hover,
               isPressed && styles.pressed,
               isFocusVisible && styles.focusVisible,
+              disabled && styles.disabled,
+              { cursor: disabled ? "not-allowed" : "pointer" }, // web only
             ]}
           >
             <Icon

--- a/packages/ui/components/toggleButton/ToggleButton.tsx
+++ b/packages/ui/components/toggleButton/ToggleButton.tsx
@@ -46,6 +46,7 @@ export const ToggleButton = forwardRef((props: ToggleButtonProps, ref) => {
       }}
       // @ts-expect-error - native base style mismatch
       style={[styles.pressable, rest.style]}
+      accessibilityPressed={isActive}
     >
       {({ isPressed, isHovered, isFocused }) => {
         return (

--- a/packages/ui/components/toggleButton/ToggleButton.tsx
+++ b/packages/ui/components/toggleButton/ToggleButton.tsx
@@ -1,0 +1,70 @@
+import { useFocusRing } from "@react-native-aria/focus";
+import { HStack } from "native-base";
+import React, { forwardRef } from "react";
+import { Platform, StyleSheet } from "react-native";
+import { tw } from "../../tailwind";
+import { Icon, IconNames } from "../icon/Icon";
+import { Pressable, PressableProps } from "../pressable/Pressable";
+
+export type ToggleButtonProps = PressableProps & {
+  name: IconNames;
+  size?: "md" | "lg";
+  isActive?: boolean;
+};
+
+export const ToggleButton = forwardRef((props: ToggleButtonProps, ref) => {
+  const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
+  const { name, isActive, size = "md", ...rest } = props;
+
+  const dimensions = size === "md" ? "h-6 w-6" : "h-8 w-8";
+
+  const styles = StyleSheet.create({
+    pressable: tw`${dimensions}`,
+    hstack: tw`h-full w-full items-center justify-center bg-transparent rounded`,
+    active: tw`bg-primary-100`,
+    hover: isActive ? tw`bg-primary-200` : tw`bg-gray-200`,
+    pressed: tw`bg-primary-200`,
+    focusVisible: Platform.OS === "web" ? tw`se-inset-focus-mini` : {},
+    disabled: tw`bg-transparent opacity-50`, // TODO opacity tbd
+  });
+
+  return (
+    <Pressable
+      ref={ref}
+      {...rest}
+      accessibilityRole={props.accessibilityRole ?? "button"}
+      // @ts-expect-error - web only
+      onFocus={focusRingProps.onFocus}
+      // @ts-expect-error - web only
+      onBlur={focusRingProps.onBlur}
+      // disable default outline styles
+      _focusVisible={{
+        _web: {
+          // @ts-expect-error - web only
+          style: [styles.pressable, rest.style, { outlineStyle: "none" }],
+        },
+      }}
+      // @ts-expect-error - native base style mismatch
+      style={[styles.pressable, rest.style]}
+    >
+      {({ isPressed, isHovered, isFocused }) => {
+        return (
+          <HStack
+            style={[
+              styles.hstack,
+              isActive && styles.active,
+              isHovered && styles.hover,
+              isPressed && styles.pressed,
+              isFocusVisible && styles.focusVisible,
+            ]}
+          >
+            <Icon
+              name={name}
+              color={isActive || isPressed ? "primary-500" : "gray-800"}
+            />
+          </HStack>
+        );
+      }}
+    </Pressable>
+  );
+});

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -57,6 +57,7 @@ export * from "./components/tabList/TabList";
 export * from "./components/tabPanel/TabPanel";
 export * from "./components/text/Text";
 export * from "./components/textArea/TextArea";
+export * from "./components/toggleButton/ToggleButton";
 export * from "./components/tooltip/Tooltip";
 export * from "./components/view/View";
 export * from "./components/workspaceAvatar/WorkspaceAvatar";


### PR DESCRIPTION
Add `ToggleButton` component and use for `EditorBottombar`, `EditorBubbleMenu` and in `PageHeader`.

- add component
- refactor `EditorBottombarButton`
- update DesignSystem

_additional_
- fix height and adjust styling for `EditorBottombarDivider`
- update border for `EditorBottombar` to make it more visible
