### PR TITLE
Add styling and basic usability to Comments Sidebar

### DIFF
--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -93,18 +93,32 @@ const CommentsSidebar: React.FC<{}> = () => {
                 Reply...
               </Text> */}
 
-              <View>
+              <View style={tw`mt-2`}>
                 {comment.replies.map((reply) => {
                   if (!reply) return null;
                   return (
                     <View key={reply.id}>
-                      <View>
-                        <Text>{reply.text}</Text>
-                        <Text variant="xs">
+                      <HStack alignItems="center">
+                        <HStack alignItems="center" space="1.5">
+                          {/* TODO if comment has been read change color to gray-400 */}
+                          <Avatar color="emerald" size="xs">
+                            ND
+                          </Avatar>
+                          <Text variant="xs" bold>
+                            Norman Dean
+                          </Text>
+                        </HStack>
+                        <IconButton name="more-line" style={tw`ml-auto`} />
+                      </HStack>
+                      <View
+                        style={tw`ml-2.75 pb-2 pl-4.25 border-l-2 border-solid border-gray-200`}
+                      >
+                        <Text variant="xxs" muted style={tw`mt-1 mb-1.5`}>
                           {formatDistanceToNow(parseJSON(reply.createdAt), {
                             addSuffix: true,
                           })}
                         </Text>
+                        <Text variant="sm">{reply.text}</Text>
                       </View>
                       <IconButton
                         name="delete-bin-line"

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -1,7 +1,7 @@
 import {
   Avatar,
-  Button,
   EditorBottombarDivider,
+  EditorSidebarHeader,
   IconButton,
   Pressable,
   RawInput,
@@ -22,18 +22,14 @@ const CommentsSidebar: React.FC<{}> = () => {
   const [state, send] = useActor(commentsService);
 
   const styles = StyleSheet.create({
-    header: tw`h-editor-sidebar-header px-4 border-b border-solid border-gray-200`,
+    header: tw`justify-between`,
     wrapper: tw`p-4 border-b border-gray-200`,
   });
 
   return (
     // grow-0 overrides default of ScrollView to keep the assigned width
     <ScrollView style={tw`w-sidebar grow-0 bg-gray-100`}>
-      <HStack
-        alignItems="center"
-        justifyContent="space-between"
-        style={styles.header}
-      >
+      <EditorSidebarHeader style={styles.header}>
         <Text variant="sm" bold>
           Comments
         </Text>
@@ -48,7 +44,7 @@ const CommentsSidebar: React.FC<{}> = () => {
             Resolved
           </Text>
         </HStack>
-      </HStack>
+      </EditorSidebarHeader>
 
       <View>
         {state.context.decryptedComments.map((comment) => {

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Pressable,
   RawInput,
   ScrollView,
+  SubmitButton,
   Text,
   tw,
   View,
@@ -116,25 +117,35 @@ const CommentsSidebar: React.FC<{}> = () => {
                   );
                 })}
               </View>
-              <RawInput
-                multiline
-                value={state.context.replyTexts[comment.id]}
-                onChangeText={(text) =>
-                  send({
-                    type: "UPDATE_REPLY_TEXT",
-                    commentId: comment.id,
-                    text,
-                  })
-                }
-              />
-              <Button
+
+              <HStack space="1.5">
+                <Avatar color="emerald" size="xs">
+                  PE
+                </Avatar>
+                <RawInput
+                  multiline
+                  value={state.context.replyTexts[comment.id]}
+                  onChangeText={(text) =>
+                    send({
+                      type: "UPDATE_REPLY_TEXT",
+                      commentId: comment.id,
+                      text,
+                    })
+                  }
+                  _stack={{
+                    height: 16,
+                    flexShrink: 1,
+                  }}
+                />
+              </HStack>
+
+              <SubmitButton
                 size="sm"
                 onPress={() =>
                   send({ type: "CREATE_REPLY", commentId: comment.id })
                 }
-              >
-                Add Reply
-              </Button>
+                style={tw`mt-1 self-end`}
+              />
 
               <IconButton
                 name="delete-bin-line"

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -89,9 +89,6 @@ const CommentsSidebar: React.FC<{}> = () => {
                   })}
                 </Text>
                 <Text variant="sm">{comment.text}</Text>
-                {/* <Text variant="xs" style={tw`py-2 text-primary-500`}>
-                Reply...
-              </Text> */}
               </View>
 
               <View style={tw`mt-2`}>
@@ -133,6 +130,7 @@ const CommentsSidebar: React.FC<{}> = () => {
               </View>
 
               <HStack space="1.5">
+                {/* TODO use active user for reply */}
                 <Avatar color="rose" size="xs">
                   FO
                 </Avatar>

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  EditorBottombarDivider,
   IconButton,
   Pressable,
   RawInput,
@@ -8,6 +9,7 @@ import {
   tw,
   View,
 } from "@serenity-tools/ui";
+import { HStack } from "native-base";
 import { useActor } from "@xstate/react";
 import { formatDistanceToNow, parseJSON } from "date-fns";
 import { StyleSheet } from "react-native";
@@ -19,13 +21,32 @@ const CommentsSidebar: React.FC<{}> = () => {
 
   const styles = StyleSheet.create({
     header: tw`h-editor-sidebar-header px-4 border-b border-solid border-gray-200`,
-    wrapper: tw`p-4`,
+    wrapper: tw`p-4 border-b border-gray-200`,
   });
 
   return (
     // grow-0 overrides default of ScrollView to keep the assigned width
     <ScrollView style={tw`w-sidebar grow-0 bg-gray-100`}>
-      <Text>Comments WIP</Text>
+      <HStack
+        alignItems="center"
+        justifyContent="space-between"
+        style={styles.header}
+      >
+        <Text variant="sm" bold>
+          Comments
+        </Text>
+        <HStack alignItems={"center"} style={tw`-mr-1`}>
+          <Text variant="xxs" muted style={tw`p-1`}>
+            Open
+          </Text>
+          <EditorBottombarDivider
+            style={tw`h-4 border-r-1.5 border-gray-600`}
+          />
+          <Text variant="xxs" muted style={tw`p-1`}>
+            Resolved
+          </Text>
+        </HStack>
+      </HStack>
 
       <View>
         {state.context.decryptedComments.map((comment) => {
@@ -34,7 +55,7 @@ const CommentsSidebar: React.FC<{}> = () => {
             <Pressable
               key={comment.id}
               style={[
-                tw`border-b border-gray-200`,
+                styles.wrapper,
                 comment.id === state.context.highlightedCommentId
                   ? tw`bg-gray-200`
                   : undefined,

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -10,11 +10,17 @@ import {
 } from "@serenity-tools/ui";
 import { useActor } from "@xstate/react";
 import { formatDistanceToNow, parseJSON } from "date-fns";
+import { StyleSheet } from "react-native";
 import { usePage } from "../../context/PageContext";
 
 const CommentsSidebar: React.FC<{}> = () => {
   const { commentsService } = usePage();
   const [state, send] = useActor(commentsService);
+
+  const styles = StyleSheet.create({
+    header: tw`h-editor-sidebar-header px-4 border-b border-solid border-gray-200`,
+    wrapper: tw`p-4`,
+  });
 
   return (
     // grow-0 overrides default of ScrollView to keep the assigned width

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   EditorBottombarDivider,
   IconButton,
@@ -64,6 +65,22 @@ const CommentsSidebar: React.FC<{}> = () => {
                 send({ type: "HIGHLIGHT_COMMENT", commentId: comment.id });
               }}
             >
+              <HStack alignItems="center">
+                <HStack alignItems="center" space="1.5">
+                  {/* TODO if comment has been read change color to gray-400 */}
+                  <Avatar color="arctic" size="xs">
+                    KD
+                  </Avatar>
+                  <Text variant="xs" bold>
+                    Karen Doe
+                  </Text>
+                  <Text variant="xxs" muted>
+                    {formatDistanceToNow(parseJSON(comment.createdAt), {
+                      addSuffix: true,
+                    })}
+                  </Text>
+                </HStack>
+              </HStack>
               <Text>{comment.text}</Text>
               <Text variant="xs">
                 {formatDistanceToNow(parseJSON(comment.createdAt), {

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -66,6 +66,11 @@ const CommentsSidebar: React.FC<{}> = () => {
               }}
             >
               <HStack alignItems="center">
+                {/* new comment indicator */}
+                <View style={tw`w-4 -ml-4 flex-row justify-center`}>
+                  <View style={tw`h-1.5 w-1.5 rounded-full bg-primary-500`} />
+                </View>
+
                 <HStack alignItems="center" space="1.5">
                   {/* TODO if comment has been read change color to gray-400 */}
                   <Avatar color="arctic" size="xs">

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -53,14 +53,17 @@ const CommentsSidebar: React.FC<{}> = () => {
       <View>
         {state.context.decryptedComments.map((comment) => {
           if (!comment) return null;
+
+          const isActiveComment =
+            comment.id === state.context.highlightedCommentId;
+
           return (
             <Pressable
               key={comment.id}
               style={[
                 styles.wrapper,
-                comment.id === state.context.highlightedCommentId
-                  ? tw`bg-gray-200`
-                  : undefined,
+                isActiveComment ? tw`bg-collaboration-honey/5` : undefined,
+                { cursor: isActiveComment ? "default" : "pointer" },
               ]}
               onPress={() => {
                 send({ type: "HIGHLIGHT_COMMENT", commentId: comment.id });

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -24,9 +24,7 @@ const CommentsSidebar: React.FC<{}> = () => {
 
   return (
     // grow-0 overrides default of ScrollView to keep the assigned width
-    <ScrollView
-      style={tw`w-sidebar grow-0 border-l border-gray-200 bg-gray-100`}
-    >
+    <ScrollView style={tw`w-sidebar grow-0 bg-gray-100`}>
       <Text>Comments WIP</Text>
 
       <View>

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -67,20 +67,20 @@ const CommentsSidebar: React.FC<{}> = () => {
             >
               <HStack alignItems="center">
                 {/* new comment indicator */}
-                <View style={tw`w-4 -ml-4 flex-row justify-center`}>
+                {/* <View style={tw`w-4 -ml-4 flex-row justify-center`}>
                   <View style={tw`h-1.5 w-1.5 rounded-full bg-primary-500`} />
-                </View>
+                </View> */}
 
                 <HStack alignItems="center" space="1.5">
                   {/* TODO if comment has been read change color to gray-400 */}
-                  <Avatar color="arctic" size="xs">
+                  {/* <Avatar color="arctic" size="xs">
                     KD
                   </Avatar>
                   <Text variant="xs" bold>
                     Karen Doe
-                  </Text>
+                  </Text> */}
                 </HStack>
-                <IconButton name="more-line" style={tw`ml-auto`} />
+                {/* <IconButton name="more-line" style={tw`ml-auto`} /> */}
               </HStack>
               <View style={tw`pl-0.5 py-2`}>
                 <Text variant="xxs" muted style={tw`mb-1.5`}>
@@ -99,14 +99,14 @@ const CommentsSidebar: React.FC<{}> = () => {
                       <HStack alignItems="center">
                         <HStack alignItems="center" space="1.5">
                           {/* TODO if comment has been read change color to gray-400 */}
-                          <Avatar color="emerald" size="xs">
+                          {/* <Avatar color="emerald" size="xs">
                             ND
                           </Avatar>
                           <Text variant="xs" bold>
                             Norman Dean
-                          </Text>
+                          </Text> */}
                         </HStack>
-                        <IconButton name="more-line" style={tw`ml-auto`} />
+                        {/* <IconButton name="more-line" style={tw`ml-auto`} /> */}
                       </HStack>
                       <View
                         style={tw`ml-2.75 pb-2 pl-4.25 border-l-2 border-solid border-gray-200`}
@@ -131,9 +131,9 @@ const CommentsSidebar: React.FC<{}> = () => {
 
               <HStack space="1.5">
                 {/* TODO use active user for reply */}
-                <Avatar color="rose" size="xs">
+                {/* <Avatar color="rose" size="xs">
                   FO
-                </Avatar>
+                </Avatar> */}
                 <RawInput
                   multiline
                   value={state.context.replyTexts[comment.id]}

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -140,6 +140,10 @@ const CommentsSidebar: React.FC<{}> = () => {
               </HStack>
 
               <SubmitButton
+                disabled={
+                  state.context.replyTexts[comment.id] === undefined ||
+                  state.context.replyTexts[comment.id] === ""
+                }
                 size="sm"
                 onPress={() =>
                   send({ type: "CREATE_REPLY", commentId: comment.id })

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -79,19 +79,20 @@ const CommentsSidebar: React.FC<{}> = () => {
                   <Text variant="xs" bold>
                     Karen Doe
                   </Text>
-                  <Text variant="xxs" muted>
-                    {formatDistanceToNow(parseJSON(comment.createdAt), {
-                      addSuffix: true,
-                    })}
-                  </Text>
                 </HStack>
+                <IconButton name="more-line" style={tw`ml-auto`} />
               </HStack>
-              <Text variant="sm" style={tw`py-2`}>
-                {comment.text}
-              </Text>
-              {/* <Text variant="xs" style={tw`text-primary-500`}>
+              <View style={tw`pl-0.5 py-2`}>
+                <Text variant="xxs" muted style={tw`mb-1.5`}>
+                  {formatDistanceToNow(parseJSON(comment.createdAt), {
+                    addSuffix: true,
+                  })}
+                </Text>
+                <Text variant="sm">{comment.text}</Text>
+                {/* <Text variant="xs" style={tw`py-2 text-primary-500`}>
                 Reply...
               </Text> */}
+              </View>
 
               <View style={tw`mt-2`}>
                 {comment.replies.map((reply) => {
@@ -132,8 +133,8 @@ const CommentsSidebar: React.FC<{}> = () => {
               </View>
 
               <HStack space="1.5">
-                <Avatar color="emerald" size="xs">
-                  PE
+                <Avatar color="rose" size="xs">
+                  FO
                 </Avatar>
                 <RawInput
                   multiline

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -86,12 +86,13 @@ const CommentsSidebar: React.FC<{}> = () => {
                   </Text>
                 </HStack>
               </HStack>
-              <Text>{comment.text}</Text>
-              <Text variant="xs">
-                {formatDistanceToNow(parseJSON(comment.createdAt), {
-                  addSuffix: true,
-                })}
+              <Text variant="sm" style={tw`py-2`}>
+                {comment.text}
               </Text>
+              {/* <Text variant="xs" style={tw`text-primary-500`}>
+                Reply...
+              </Text> */}
+
               <View>
                 {comment.replies.map((reply) => {
                   if (!reply) return null;

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -58,7 +58,7 @@ const CommentsSidebar: React.FC<{}> = () => {
               key={comment.id}
               style={[
                 styles.wrapper,
-                isActiveComment ? tw`bg-collaboration-honey/5` : undefined,
+                isActiveComment ? tw`bg-collaboration-honey/7` : undefined,
                 { cursor: isActiveComment ? "default" : "pointer" },
               ]}
               onPress={() => {

--- a/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
+++ b/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
@@ -26,7 +26,7 @@ export function PageHeaderRight() {
       <HStack
         style={tw`h-full ${
           hasEditorSidebar ? "w-sidebar border-l bg-gray-100" : ""
-        } px-3 border-b border-gray-200`}
+        } pl-3 pr-4 border-b border-gray-200`}
         justifyContent="space-between"
         alignItems="center"
         space={hasEditorSidebar ? 0 : 4}

--- a/packages/ui/components/editorSidebarHeader/EditorSidebarHeader.tsx
+++ b/packages/ui/components/editorSidebarHeader/EditorSidebarHeader.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { tw } from "../../tailwind";
+import { View, ViewProps } from "../view/View";
+
+export type EditorSidebarHeaderProps = ViewProps & {};
+
+export const EditorSidebarHeader = React.forwardRef(
+  (props: EditorSidebarHeaderProps, ref) => {
+    return (
+      <View
+        {...props}
+        style={[
+          tw`flex-row items-center h-editor-sidebar-header px-4 border-b border-gray-200`,
+          props.style,
+        ]}
+      />
+    );
+  }
+);

--- a/packages/ui/components/submitButton/SubmitButton.tsx
+++ b/packages/ui/components/submitButton/SubmitButton.tsx
@@ -9,9 +9,8 @@ import { Spinner } from "../spinner/Spinner";
 import { Text } from "../text/Text";
 
 export type SubmitButtonProps = PressableProps & {
-  // name: IconNames;
   label?: string;
-  size?: "md" | "lg" | "xl";
+  size?: "sm" | "md" | "lg" | "xl";
   isLoading?: boolean;
 };
 
@@ -23,17 +22,19 @@ export const SubmitButton = forwardRef((props: SubmitButtonProps, ref) => {
 
   // the pressable style sizing defines the clickable area
   const pressableSize = {
+    sm: "h-6 w-6",
     md: "h-6 w-6",
     lg: "h-8 w-8",
     xl: "h-12 w-12",
   };
 
   // the dimensions of the button define the visible area when clicked or hovered
-  let dimensions = size === "md" ? "w-6 h-6" : "w-8 h-8";
-
-  if (label) {
-    dimensions = "w-auto h-auto";
-  }
+  const dimensions = {
+    sm: "w-5 h-5",
+    md: "w-6 h-6",
+    lg: "w-8 h-8",
+    xl: "w-8 h-8",
+  };
 
   // --- dev only
   // const showClickableArea = true;
@@ -41,12 +42,12 @@ export const SubmitButton = forwardRef((props: SubmitButtonProps, ref) => {
   const styles = StyleSheet.create({
     pressable: tw.style(
       label
-        ? dimensions
+        ? "w-auto h-auto"
         : tw`flex justify-center items-center ${pressableSize[size]}`
       // showClickableArea && tw`bg-collaboration-honey/40`
     ),
     stack: tw.style(
-      `${dimensions} flex ${
+      `${dimensions[size]} flex ${
         !label ? "justify-center" : ""
       } items-center rounded-full ${label ? `pl-1.5 pr-3 py-1 rounded` : ""}`
     ),
@@ -111,6 +112,8 @@ export const SubmitButton = forwardRef((props: SubmitButtonProps, ref) => {
               <Icon
                 name={"arrow-up-line"}
                 color={disabled ? "primary-300" : "gray-100"}
+                size={size === "sm" ? 3 : 4}
+                mobileSize={size === "sm" ? 4 : 5}
               />
             )}
 

--- a/packages/ui/components/tabList/TabList.tsx
+++ b/packages/ui/components/tabList/TabList.tsx
@@ -1,17 +1,20 @@
 import React from "react";
 import { tw } from "../../tailwind";
-import { View, ViewProps } from "../view/View";
+import {
+  EditorSidebarHeader,
+  EditorSidebarHeaderProps,
+} from "../editorSidebarHeader/EditorSidebarHeader";
 
-export type TabListProps = ViewProps & {
+export type TabListProps = EditorSidebarHeaderProps & {
   accessibilityLabel: string;
 };
 
 export function TabList(props: TabListProps) {
   return (
-    <View
+    <EditorSidebarHeader
       {...props}
       accessibilityRole="tablist"
-      style={[tw`flex-row py-2.5 px-2 border-b border-gray-200`, props.style]}
+      style={tw`px-2`}
     />
   );
 }

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -12,6 +12,7 @@ export * from "./components/designSystem/DesignSystemMono";
 export * from "./components/editorBottombarButton/EditorBottombarButton";
 export * from "./components/editorBottombarDivider/EditorBottombarDivider";
 export * from "./components/editorSidebarIcon/EditorSidebarIcon";
+export * from "./components/editorSidebarHeader/EditorSidebarHeader";
 export * from "./components/formWrapper/FormWrapper";
 export * from "./components/heading/Heading";
 export * from "./components/icon/Icon";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,6 +124,7 @@ const customTheme = {
     height: {
       "top-bar": "3rem",
       "form-element": "3rem",
+      "editor-sidebar-header": "3.125rem",
     },
     margin: {
       4.5: "1.125rem",


### PR DESCRIPTION
Style the basic elements for _comments_ and _replies_ in the `CommentsSidebar`

- add new-comment indicator
- add general structure for user-related data (user-bubble, name)
- add component `EditorSidebarHeader` for unified styling and usage
- style replies
- use `SubmitButton` for replies
- rearrange comment-header to make room for upcoming comment-actions

_additional:_

- add _size_ to `SubmitButton` for sizing depending on context
- adjust padding for `PageHeaderRight`