### PR TITLE
Widen Editor-content max-width

### DIFF
--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -49,7 +49,7 @@
 
   /* needed to make all area of the editor clickable which enables activating the cursor on each written line */
   .ProseMirror > * {
-    @apply mx-auto w-full max-w-prose-rem;
+    @apply mx-auto w-full max-w-editor-content;
   }
 
   /* needed so margin of first element doesn't make content 'jump' */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -134,6 +134,7 @@ const customTheme = {
     },
     maxWidth: {
       "prose-rem": "36.5rem", // editor specific .. needed as representation of a 65ch content-width as the "ch"-unit would only work on text-elements
+      "editor-content": "44rem",
       "navigation-drawer-modal": "61rem",
     },
     width: {


### PR DESCRIPTION
Increase the max-width of `Editor` content to _44rem_ to increase the user-experience for the majority of users.

As note-taking, document sharing or knowledge bases focus more on finding information quickly, rather than continuous reading, we widen the content-elements of the Editor.

In future we might want to think about a toggle of some sorts to provide a switch between a sort of _read-mode_ - which uses the typical reading width of 60-80characters per line - and a wider mode for overviews.

