### PR TITLE
Adjust sizings in CommentsSidebar

### DIFF
--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -87,7 +87,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                       key={commentCreator.userId}
                       color={hashToCollaboratorColor(commentCreator.userId)}
                     >
-                      {commentCreator.username?.split("@")[0].substring(0, 2)}
+                      {commentCreator.username?.split("@")[0].substring(0, 1)}
                     </Avatar>
                   ) : (
                     <Avatar color="arctic" size="xs">
@@ -133,7 +133,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                             >
                               {replyCreator.username
                                 ?.split("@")[0]
-                                .substring(0, 2)}
+                                .substring(0, 1)}
                             </Avatar>
                           ) : (
                             <Avatar color="arctic" size="xs">

--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -34,7 +34,7 @@ const CommentsSidebar: React.FC<{}> = () => {
     // grow-0 overrides default of ScrollView to keep the assigned width
     <ScrollView style={tw`w-sidebar grow-0 bg-gray-100`}>
       <EditorSidebarHeader style={styles.header}>
-        <Text variant="sm" bold>
+        <Text variant="xs" bold>
           Comments
         </Text>
         <HStack alignItems={"center"} style={tw`-mr-1`}>
@@ -86,6 +86,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                     <Avatar
                       key={commentCreator.userId}
                       color={hashToCollaboratorColor(commentCreator.userId)}
+                      size="xs"
                     >
                       {commentCreator.username?.split("@")[0].substring(0, 1)}
                     </Avatar>
@@ -95,7 +96,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                     </Avatar>
                   )}
 
-                  <Text variant="xs" bold>
+                  <Text variant="xxs" bold>
                     {commentCreator?.username || "External"}
                   </Text>
                 </HStack>
@@ -107,7 +108,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                     addSuffix: true,
                   })}
                 </Text>
-                <Text variant="sm">{comment.text}</Text>
+                <Text variant="xs">{comment.text}</Text>
               </View>
 
               <View style={tw`mt-2`}>
@@ -123,13 +124,14 @@ const CommentsSidebar: React.FC<{}> = () => {
                     <View key={reply.id}>
                       <HStack alignItems="center">
                         <HStack alignItems="center" space="1.5">
-                          {/* TODO if comment has been read change color to gray-400 */}
+                          {/* TODO if comment has been read change color to gray */}
                           {replyCreator ? (
                             <Avatar
                               key={replyCreator.userId}
                               color={hashToCollaboratorColor(
                                 replyCreator.userId
                               )}
+                              size="xs"
                             >
                               {replyCreator.username
                                 ?.split("@")[0]
@@ -140,7 +142,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                               E
                             </Avatar>
                           )}
-                          <Text variant="xs" bold>
+                          <Text variant="xxs" bold>
                             {replyCreator?.username || "External"}
                           </Text>
                         </HStack>
@@ -154,7 +156,7 @@ const CommentsSidebar: React.FC<{}> = () => {
                             addSuffix: true,
                           })}
                         </Text>
-                        <Text variant="sm">{reply.text}</Text>
+                        <Text variant="xs">{reply.text}</Text>
                       </View>
                       <IconButton
                         name="delete-bin-line"

--- a/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
+++ b/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
@@ -54,7 +54,7 @@ export function PageHeaderRight() {
                       key={member.userId}
                       color={hashToCollaboratorColor(member.userId)}
                     >
-                      {member.username?.split("@")[0].substring(0, 2)}
+                      {member.username?.split("@")[0].substring(0, 1)}
                     </Avatar>
                   );
                 })}

--- a/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
+++ b/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
@@ -169,13 +169,13 @@ export default function DesignSystemScreen(
         </Text>
         <DSExampleArea>
           <HStack space={2} alignItems="center" style={tw`pr-2`}>
-            <Avatar size={"xxs"}>BE</Avatar>
-            <Avatar size={"xs"}>BE</Avatar>
-            <Avatar size={"sm"}>NG</Avatar>
-            <Avatar size={"md"}>AB</Avatar>
-            <Avatar size={"lg"}>SK</Avatar>
-            <Avatar size={"xl"}>AD</Avatar>
-            <Avatar size={"2xl"}>HG</Avatar>
+            <Avatar size={"xxs"}>B</Avatar>
+            <Avatar size={"xs"}>B</Avatar>
+            <Avatar size={"sm"}>N</Avatar>
+            <Avatar size={"md"}>A</Avatar>
+            <Avatar size={"lg"}>S</Avatar>
+            <Avatar size={"xl"}>A</Avatar>
+            <Avatar size={"2xl"}>H</Avatar>
           </HStack>
         </DSExampleArea>
         <Heading lvl={3}>Styling</Heading>
@@ -184,11 +184,11 @@ export default function DesignSystemScreen(
           <DSMono variant="property">color</DSMono> property.
         </Text>
         <DSExampleArea>
-          <Avatar color="arctic">BE</Avatar>
-          <Avatar color="lavender">NG</Avatar>
-          <Avatar color="rose">AB</Avatar>
-          <Avatar color="honey">SK</Avatar>
-          <Avatar color="emerald">AD</Avatar>
+          <Avatar color="arctic">B</Avatar>
+          <Avatar color="lavender">N</Avatar>
+          <Avatar color="rose">A</Avatar>
+          <Avatar color="honey">S</Avatar>
+          <Avatar color="emerald">A</Avatar>
         </DSExampleArea>
         <Heading lvl={3}>Grouping</Heading>
         <Text variant="sm">
@@ -198,11 +198,11 @@ export default function DesignSystemScreen(
         </Text>
         <DSExampleArea>
           <AvatarGroup max={3} _avatar={{ size: "sm" }}>
-            <Avatar color="arctic">SK</Avatar>
-            <Avatar color="lavender">NG</Avatar>
-            <Avatar color="rose">AN</Avatar>
-            <Avatar color="honey">NG</Avatar>
-            <Avatar color="sky">NG</Avatar>
+            <Avatar color="arctic">S</Avatar>
+            <Avatar color="lavender">N</Avatar>
+            <Avatar color="rose">A</Avatar>
+            <Avatar color="honey">N</Avatar>
+            <Avatar color="sky">N</Avatar>
           </AvatarGroup>
         </DSExampleArea>
         <Heading lvl={3}>Status</Heading>
@@ -215,19 +215,19 @@ export default function DesignSystemScreen(
         <DSExampleArea>
           <AvatarGroup max={3} _avatar={{ size: "sm" }}>
             <Avatar status="active" color="arctic">
-              SK
+              S
             </Avatar>
             <Avatar status="active" color="lavender">
-              NG
+              N
             </Avatar>
             <Avatar status="inactive" color="rose">
-              AN
+              A
             </Avatar>
             <Avatar status="inactive" color="honey">
-              NG
+              N
             </Avatar>
             <Avatar status="inactive" color="sky">
-              NG
+              N
             </Avatar>
           </AvatarGroup>
         </DSExampleArea>
@@ -592,7 +592,7 @@ export default function DesignSystemScreen(
           style={tw`h-40 mt-4 border border-gray-200 rounded overflow-hidden`}
         >
           <CenterContent>
-            <Avatar size={"md"}>AV</Avatar>
+            <Avatar size={"md"}>A</Avatar>
           </CenterContent>
         </View>
         <Heading lvl={3}>Background</Heading>

--- a/apps/app/navigation/screens/workspaceSettingsMembersScreen/WorkspaceSettingsMembersScreen.tsx
+++ b/apps/app/navigation/screens/workspaceSettingsMembersScreen/WorkspaceSettingsMembersScreen.tsx
@@ -290,7 +290,7 @@ export default function WorkspaceSettingsMembersScreen(
                   member.username.indexOf("@")
                 );
                 // TODO actually use initials when we have a username
-                const initials = username.substring(0, 2);
+                const initials = username.substring(0, 1);
                 const email = member.username;
 
                 const allowEditing = isAdmin && member.userId !== adminUserId;

--- a/packages/ui/components/avatar/Avatar.tsx
+++ b/packages/ui/components/avatar/Avatar.tsx
@@ -3,10 +3,9 @@ import React, { forwardRef } from "react";
 import { StyleSheet } from "react-native";
 import { tw } from "../../tailwind";
 import { CollaborationColor } from "../../types";
-import { View } from "../view/View";
 
 export type AvatarSize = "2xl" | "xl" | "lg" | "md" | "sm" | "xs" | "xxs";
-export type AvatarStatus = "active" | "inactive" | "default";
+export type AvatarStatus = "active" | "inactive";
 
 type CustomAvatarProps = {
   color?: CollaborationColor;
@@ -20,26 +19,35 @@ export const Avatar = forwardRef((props: AvatarProps, ref) => {
   const {
     size = "sm",
     color = "serenity",
-    status = "default",
+    status = "active",
   }: CustomAvatarProps = props;
   const styles = StyleSheet.create({
     avatar: tw``,
   });
 
-  const statusStyling = {
-    active: tw`border-2 border-white`,
-    inactive: tw`opacity-50`,
-    default: tw``,
+  const borderWidth = {
+    "2xl": 4,
+    xl: 4,
+    lg: 3,
+    md: 3,
+    sm: 2,
+    xs: 2,
+    xxs: 0,
   };
 
-  const activeIndicatorSize = {
-    "2xl": 33,
-    xl: 25,
-    lg: 17,
-    md: 13,
-    sm: 9,
-    xs: 7,
-    xxs: 6,
+  const fontSize = {
+    "2xl": 64,
+    xl: 48,
+    lg: 32,
+    md: 24,
+    sm: 14,
+    xs: 11,
+    xxs: 8,
+  };
+
+  const statusStyling = {
+    active: tw`border-${borderWidth[size]} border-solid border-white/60`,
+    inactive: tw`opacity-40`,
   };
 
   return (
@@ -49,19 +57,11 @@ export const Avatar = forwardRef((props: AvatarProps, ref) => {
       style={[styles.avatar, statusStyling[status], props.style]}
       _text={{
         fontFamily: "Inter_600SemiBold",
+        fontSize: fontSize[size],
         style: tw`uppercase`,
       }}
       bg={`collaboration.${color}`}
     >
-      {status === "active" ? (
-        <View
-          style={[
-            tw`absolute w-${activeIndicatorSize[size]} h-${activeIndicatorSize[size]} bg-transparent`,
-            tw`rounded-full border-2 border-collaboration-${color}`,
-            { zIndex: -1 },
-          ]}
-        />
-      ) : null}
       {props.children}
     </NbAvatar>
   );

--- a/packages/ui/components/workspaceAvatar/WorkspaceAvatar.tsx
+++ b/packages/ui/components/workspaceAvatar/WorkspaceAvatar.tsx
@@ -27,6 +27,7 @@ export const WorkspaceAvatar = React.forwardRef(
         {...props}
         // TODO adjust color for each workspace if no image is set
         bg={tw.color(`collaboration-${customColor}`)}
+        style={tw`border-0`} // override for Avatar
         borderRadius={4}
         size={size}
       >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,7 @@ const customColors = {
     lavender: "#515DCE",
     purple: "#9E36CF",
     slate: "#4F5D78",
+    gray: "#CBCBD3", // for read comment
   },
   error: {
     100: "#FFEDEF",


### PR DESCRIPTION
Adjust the sizing for `Avatar` and `Text` styles inside the `CommentsSidebar`.

_including:_
- refactoring _font-size_ and _colors_ for `Avatar` component
- only use one letter for Avatars without an Image