### PR TITLE
Hover for comment-markings in Editor

### DIFF
--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -356,10 +356,12 @@
     background-color: theme("colors.comment.default");
   }
 
-  .editor-comment-active {
-    /* display setting needed to properly size background and add border */
-    display: inline-block;
-    border-bottom: 0.125rem solid theme("colors.comment.active");
+  .editor-comment:hover {
+    background-color: theme("colors.comment.hover");
+  }
+
+  .editor-comment-active,
+  .editor-comment-active:hover {
     background-color: theme("colors.comment.active");
   }
 }

--- a/packages/editor/extensions/commentsExtension/commentsExtension.ts
+++ b/packages/editor/extensions/commentsExtension/commentsExtension.ts
@@ -71,10 +71,9 @@ const createCommentsDecorationSet = (
     state.doc,
     comments.map((comment) => {
       return Decoration.inline(comment.absoluteFrom, comment.absoluteTo, {
-        class:
-          comment.id === highlightedCommentId
-            ? "editor-comment-active"
-            : "editor-comment",
+        class: `editor-comment ${
+          comment.id === highlightedCommentId && "editor-comment--active"
+        }`,
       });
     })
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -58,7 +58,7 @@ const customColors = {
   comment: {
     default: "#FFB92120", // collaboration-honey 20%
     hover: "#FFB92130", // collaboration-honey 30%
-    active: "#FFB921", // collaboration-honey
+    active: "#FFB92180", // collaboration-honey 80%
   },
   muted: "#8A8B96", // gray 600
   backdrop: "#1F1F2140", // backdrop color including opacity


### PR DESCRIPTION
Add _hover_ styling for comment-markings in `Editor` and adjust opacity to make overlapping visible.