### PR TITLE
Improve comment markings in Editor

### DIFF
--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -350,19 +350,49 @@
   }
 
   .editor-comment {
+    position: relative;
     /* display setting needed to properly size background and add border */
     display: inline-block;
+  }
+
+  .editor-comment,
+  .editor-comment:before,
+  .editor-comment:after {
     background-color: theme("colors.comment.default");
     -webkit-box-shadow: 0px 2px 0px 0px theme("colors.comment.active");
     -moz-box-shadow: 0px 2px 0px 0px theme("colors.comment.active");
     box-shadow: 0px 2px 0px 0px theme("colors.comment.active");
   }
 
-  .editor-comment-overlap {
+  .editor-comment:first-child:before,
+  .editor-comment:not(.editor-comment-overlap)
+    + .editor-comment:not(.editor-comment-overlap):before,
+  .editor-comment:last-child:after,
+  .editor-comment + .editor-comment:not(.editor-comment-overlap):after {
+    position: absolute;
+    display: inline-block;
+    content: "";
+    width: 0.2ch;
+    height: 100%;
+  }
+
+  .editor-comment:before {
+    left: -0.2ch;
+  }
+
+  .editor-comment:after {
+    right: -0.2ch;
+  }
+
+  .editor-comment-overlap,
+  .editor-comment-overlap:before,
+  .editor-comment-overlap:after {
     background-color: theme("colors.comment.hover");
   }
 
-  .editor-comment-active {
+  .editor-comment-active,
+  .editor-comment-active:before,
+  .editor-comment-active:after {
     background-color: theme("colors.comment.active");
   }
 }

--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -352,8 +352,10 @@
   .editor-comment {
     /* display setting needed to properly size background and add border */
     display: inline-block;
-    border-bottom: 0.125rem solid theme("colors.comment.active");
     background-color: theme("colors.comment.default");
+    -webkit-box-shadow: 0px 2px 0px 0px theme("colors.comment.active");
+    -moz-box-shadow: 0px 2px 0px 0px theme("colors.comment.active");
+    box-shadow: 0px 2px 0px 0px theme("colors.comment.active");
   }
 
   .editor-comment-overlap {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -58,7 +58,7 @@ const customColors = {
   },
   comment: {
     default: "#FFB92120", // collaboration-honey 20%
-    hover: "#FFB92130", // collaboration-honey 30%
+    hover: "#FFB92140", // collaboration-honey 40%
     active: "#FFB92180", // collaboration-honey 80%
   },
   muted: "#8A8B96", // gray 600


### PR DESCRIPTION
Improve overall styling for comment-markings inside the `Editor`.

- add additional area before and after marking
- adjust overlapping colors for better visibility
- use _shadow_ instead of _border_ to avoid size-changes