### PR TITLE
Improve PageHeader for mobile

### DIFF
--- a/apps/app/components/page/PageHeader.tsx
+++ b/apps/app/components/page/PageHeader.tsx
@@ -24,16 +24,18 @@ export const PageHeader: React.FC<Props> = ({ toggleCommentsDrawer }) => {
           </Text>
         </HStack>
       ) : null}
-      <Tooltip label="Toggle Comments" placement="left" offset={8}>
-        <ToggleButton
-          onPress={() => {
-            toggleCommentsDrawer();
-          }}
-          name="chat-4-line"
-          size={"lg"}
-          testID="open-comments-drawer-button"
-        />
-      </Tooltip>
+      {isDesktopDevice ? (
+        <Tooltip label="Toggle Comments" placement="left" offset={8}>
+          <ToggleButton
+            onPress={() => {
+              toggleCommentsDrawer();
+            }}
+            name="chat-4-line"
+            size={"lg"}
+            testID="open-comments-drawer-button"
+          />
+        </Tooltip>
+      ) : null}
     </>
   );
 };

--- a/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
+++ b/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
@@ -12,9 +12,14 @@ import { HStack } from "native-base";
 import { useState } from "react";
 import { useWorkspace } from "../../context/WorkspaceContext";
 import { useEditorStore } from "../../utils/editorStore/editorStore";
+import PageHeaderRightMenu from "../pageHeaderRightMenu/PageHeaderRightMenu";
 import { PageShareModalContent } from "../pageShareModalContent/PageShareModalContent";
 
-export function PageHeaderRight() {
+type Props = {
+  toggleCommentsDrawer: () => void;
+};
+
+export const PageHeaderRight: React.FC<Props> = ({ toggleCommentsDrawer }) => {
   const hasEditorSidebar = useHasEditorSidebar();
   const { workspaceQueryResult } = useWorkspace();
   const [isActiveShareModal, setIsActiveShareModal] = useState(false);
@@ -72,16 +77,14 @@ export function PageHeaderRight() {
                 Share
               </Button>
             ) : (
-              <>
-                <IconButton
-                  name="share-line"
-                  size="xl"
-                  color="gray-900"
-                  onPress={() => {
-                    setIsActiveShareModal(true);
-                  }}
-                />
-              </>
+              <PageHeaderRightMenu
+                onSharePressed={() => {
+                  setIsActiveShareModal(true);
+                }}
+                onCommentsPressed={() => {
+                  toggleCommentsDrawer();
+                }}
+              />
             )}
           </>
         )}
@@ -96,4 +99,4 @@ export function PageHeaderRight() {
       </Modal>
     </>
   );
-}
+};

--- a/apps/app/components/pageHeaderRightMenu/PageHeaderRightMenu.tsx
+++ b/apps/app/components/pageHeaderRightMenu/PageHeaderRightMenu.tsx
@@ -1,0 +1,55 @@
+import { IconButton, Menu, MenuButton, tw } from "@serenity-tools/ui";
+import { useState } from "react";
+
+type Props = {
+  onSharePressed: () => void;
+  onCommentsPressed: () => void;
+};
+
+export default function PageHeaderRightMenu(props: Props) {
+  const [isOpenMenu, setIsOpenMenu] = useState(false);
+
+  return (
+    <Menu
+      {...props}
+      bottomSheetModalProps={{
+        snapPoints: [180],
+      }}
+      popoverProps={{
+        placement: "bottom left",
+        offset: 6,
+        style: tw`w-60`,
+      }}
+      isOpen={isOpenMenu}
+      onChange={setIsOpenMenu}
+      trigger={
+        <IconButton
+          accessibilityLabel="More options menu"
+          size={"xl"}
+          name="more-line"
+          color="gray-700"
+          style={tw`p-2`}
+        ></IconButton>
+      }
+    >
+      <MenuButton
+        onPress={() => {
+          setIsOpenMenu(false);
+          props.onSharePressed();
+        }}
+        iconName={"share-line"}
+      >
+        Share
+      </MenuButton>
+      <MenuButton
+        onPress={() => {
+          setIsOpenMenu(false);
+          props.onCommentsPressed();
+        }}
+        iconName={"chat-4-line"}
+      >
+        Comments
+      </MenuButton>
+    </Menu>
+  );
+}

--- a/apps/app/navigation/screens/pageScreen/PageScreen.tsx
+++ b/apps/app/navigation/screens/pageScreen/PageScreen.tsx
@@ -62,7 +62,13 @@ const ActualPageScreen = (props: WorkspaceDrawerScreenProps<"Page">) => {
 
   useLayoutEffect(() => {
     props.navigation.setOptions({
-      headerRight: PageHeaderRight,
+      headerRight: () => (
+        <PageHeaderRight
+          toggleCommentsDrawer={() => {
+            send({ type: "TOGGLE_SIDEBAR" });
+          }}
+        />
+      ),
       headerTitle: () => (
         <PageHeader
           toggleCommentsDrawer={() => {


### PR DESCRIPTION
Only show comments-icon for _desktop_ and use new `PageHeaderRightMenu` for mobile.