### PR TITLE
Update comment toggle

### DIFF
--- a/apps/app/components/page/PageHeader.tsx
+++ b/apps/app/components/page/PageHeader.tsx
@@ -31,7 +31,12 @@ export const PageHeader: React.FC<Props> = ({
         </HStack>
       ) : null}
       {isDesktopDevice ? (
-        <Tooltip label="Toggle Comments" placement="left" offset={8}>
+        <Tooltip
+          label="Toggle Comments"
+          placement="left"
+          offset={8}
+          openDelay={1200}
+        >
           <ToggleButton
             onPress={() => {
               toggleCommentsDrawer();
@@ -39,6 +44,7 @@ export const PageHeader: React.FC<Props> = ({
             isActive={isOpenSidebar}
             name={hasNewComment ? "chat-4-line-dot" : "chat-4-line"}
             size={"lg"}
+            subtle
             testID="open-comments-drawer-button"
           />
         </Tooltip>

--- a/apps/app/components/page/PageHeader.tsx
+++ b/apps/app/components/page/PageHeader.tsx
@@ -9,9 +9,15 @@ import { useEditorStore } from "../../utils/editorStore/editorStore";
 
 type Props = {
   toggleCommentsDrawer: () => void;
+  isOpenSidebar: boolean;
+  hasNewComment: boolean;
 };
 
-export const PageHeader: React.FC<Props> = ({ toggleCommentsDrawer }) => {
+export const PageHeader: React.FC<Props> = ({
+  toggleCommentsDrawer,
+  isOpenSidebar,
+  hasNewComment,
+}) => {
   const isInEditingMode = useEditorStore((state) => state.isInEditingMode);
   const isDesktopDevice = useIsDesktopDevice();
 
@@ -30,7 +36,8 @@ export const PageHeader: React.FC<Props> = ({ toggleCommentsDrawer }) => {
             onPress={() => {
               toggleCommentsDrawer();
             }}
-            name="chat-4-line"
+            isActive={isOpenSidebar}
+            name={hasNewComment ? "chat-4-line-dot" : "chat-4-line"}
             size={"lg"}
             testID="open-comments-drawer-button"
           />

--- a/apps/app/components/pageHeaderLeft/PageHeaderLeft.tsx
+++ b/apps/app/components/pageHeaderLeft/PageHeaderLeft.tsx
@@ -39,7 +39,7 @@ export function PageHeaderLeft(props: any) {
     <HStack alignItems={"center"}>
       {!isPermanentLeftSidebar ? (
         <View style={isDesktopDevice ? tw`pl-3` : tw`pl-2`}>
-          {isInEditingMode ? (
+          {isInEditingMode && !isDesktopDevice ? (
             <HStack>
               <IconButton
                 size={"xl"}

--- a/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
+++ b/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
@@ -1261,6 +1261,7 @@ export default function DesignSystemScreen(
             <IconTile name="chat-4-fill" />
             <IconTile name="chat-4-line" />
             <IconTile name="chat-4-line-message" />
+            <IconTile name="chat-4-line-dot" />
             <IconTile name="chit-chat" />
             <IconTile name="pencil-line" />
             <IconTile name="error-warning-line" />

--- a/apps/app/navigation/screens/pageScreen/PageScreen.tsx
+++ b/apps/app/navigation/screens/pageScreen/PageScreen.tsx
@@ -74,10 +74,12 @@ const ActualPageScreen = (props: WorkspaceDrawerScreenProps<"Page">) => {
           toggleCommentsDrawer={() => {
             send({ type: "TOGGLE_SIDEBAR" });
           }}
+          isOpenSidebar={commentsState.context.isOpenSidebar}
+          hasNewComment={false} // TODO
         />
       ),
     });
-  }, []);
+  }, [commentsState]);
 
   const updateDocumentFolderPath = async (docId: string) => {
     const documentPath = await getDocumentPath(docId);

--- a/packages/ui/components/icon/Icon.tsx
+++ b/packages/ui/components/icon/Icon.tsx
@@ -29,6 +29,7 @@ import { Chat1Line } from "./icons/Chat1Line";
 import { Chat1LineMessage } from "./icons/Chat1LineMessage";
 import { Chat4Fill } from "./icons/Chat4Fill";
 import { Chat4Line } from "./icons/Chat4Line";
+import { Chat4LineDot } from "./icons/Chat4LineDot";
 import { Chat4LineMessage } from "./icons/Chat4LineMessage";
 import { CheckLine } from "./icons/CheckLine";
 import { ChitChat } from "./icons/ChitChat";
@@ -153,6 +154,7 @@ export type IconNames =
   | "chat-1-line-message"
   | "chat-4-fill"
   | "chat-4-line"
+  | "chat-4-line-dot"
   | "chat-4-line-message"
   | "check-line"
   | "chit-chat"
@@ -347,6 +349,9 @@ export const Icon = (props: IconProps) => {
   }
   if (name === "chat-4-line") {
     icon = <Chat4Line color={color} size={iconSize} />;
+  }
+  if (name === "chat-4-line-dot") {
+    icon = <Chat4LineDot color={color} size={iconSize} />;
   }
   if (name === "chat-4-line-message") {
     icon = <Chat4LineMessage color={color} size={iconSize} />;

--- a/packages/ui/components/icon/icons/Chat4LineDot.tsx
+++ b/packages/ui/components/icon/icons/Chat4LineDot.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Svg, { Path, Circle } from "react-native-svg";
+
+export type Props = { color: string; size: string };
+
+export const Chat4LineDot = ({ color, size }: Props) => {
+  return (
+    <Svg height={size} width={size} viewBox="0 0 16 16">
+      <Path fill="none" d="M0 0h16v16H0z" />
+      <Circle cx="13.5" cy="2.5" r="2.5" fill="#435BF8" />
+      <Path
+        fill={color}
+        d="M10 2H1.99998C1.82317 2 1.6536 2.07024 1.52858 2.19526C1.40355 2.32029 1.33331 2.48986 1.33331 2.66667V15L4.30331 12.6667H14C14.1768 12.6667 14.3464 12.5964 14.4714 12.4714C14.5964 12.3464 14.6666 12.1768 14.6666 12V6H13.3333V11.3333H3.84198L2.66665 12.2567V3.33333H10V2Z"
+      />
+    </Svg>
+  );
+};

--- a/packages/ui/components/iconButton/IconButton.tsx
+++ b/packages/ui/components/iconButton/IconButton.tsx
@@ -19,8 +19,6 @@ export type IconButtonProps = PressableProps & {
   isActive?: boolean;
 };
 
-// TODO IconButton active state
-
 export const IconButton = forwardRef((props: IconButtonProps, ref) => {
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
   const {

--- a/packages/ui/components/iconButton/IconButton.tsx
+++ b/packages/ui/components/iconButton/IconButton.tsx
@@ -16,7 +16,10 @@ export type IconButtonProps = PressableProps & {
   size?: "md" | "lg" | "xl";
   transparent?: boolean;
   isLoading?: boolean;
+  isActive?: boolean;
 };
+
+// TODO IconButton active state
 
 export const IconButton = forwardRef((props: IconButtonProps, ref) => {
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
@@ -27,6 +30,7 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
     transparent,
     label,
     isLoading,
+    isActive,
     ...rest
   } = props;
 
@@ -70,6 +74,9 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
     hover: transparent ? tw`bg-${iconColor}/15` : tw`bg-gray-200`,
     pressed: transparent ? tw`bg-${iconColor}/25` : tw`bg-gray-300`,
     focusVisible: Platform.OS === "web" ? tw`se-inset-focus-mini` : {},
+    active: transparent
+      ? tw`border border-${iconColor}/20 bg-${iconColor}/10`
+      : tw`border border-gray-200 bg-gray-150`,
   });
 
   return (
@@ -93,6 +100,7 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
             style={[
               styles.stack,
               isHovered && !isLoading && styles.hover,
+              isActive && styles.active,
               isPressed && !isLoading && styles.pressed,
               isFocusVisible && styles.focusVisible,
             ]}
@@ -114,7 +122,11 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
             ) : (
               <Icon
                 name={name}
-                color={isHovered && !transparent ? "gray-800" : iconColor}
+                color={
+                  (isHovered || isActive) && !transparent
+                    ? "gray-800"
+                    : iconColor
+                }
               />
             )}
 
@@ -122,7 +134,7 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
               <Text
                 variant="xs"
                 style={
-                  isHovered && !transparent
+                  (isHovered || isActive) && !transparent
                     ? tw`text-gray-800`
                     : tw`text-${iconColor}`
                 }

--- a/packages/ui/components/toggleButton/ToggleButton.tsx
+++ b/packages/ui/components/toggleButton/ToggleButton.tsx
@@ -10,22 +10,27 @@ export type ToggleButtonProps = PressableProps & {
   name: IconNames;
   size?: "md" | "lg";
   isActive?: boolean;
+  subtle?: boolean;
 };
 
 export const ToggleButton = forwardRef((props: ToggleButtonProps, ref) => {
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
-  const { name, isActive, size = "md", disabled, ...rest } = props;
+  const { name, isActive, size = "md", disabled, subtle, ...rest } = props;
 
   const dimensions = size === "md" ? "h-6 w-6" : "h-8 w-8";
+  const opacity = subtle ? "60" : "100";
 
   const styles = StyleSheet.create({
     pressable: tw`${dimensions}`,
     hstack: tw`h-full w-full items-center justify-center bg-transparent rounded`,
-    active: tw`bg-primary-100`,
-    hover: isActive ? tw`bg-primary-200` : tw`bg-gray-200`,
-    pressed: tw`bg-primary-200`,
+    active: tw`bg-primary-100/${opacity}`,
+    hover: isActive
+      ? tw`bg-primary-200/${opacity}`
+      : tw`bg-gray-200/${opacity}`,
+    pressed: tw`bg-primary-200/${opacity}`,
     focusVisible: Platform.OS === "web" ? tw`se-inset-focus-mini` : {},
     disabled: tw`bg-transparent opacity-50`, // TODO opacity tbd
+    subtle: isActive ? tw`border border-primary-100` : tw``,
   });
 
   return (
@@ -54,6 +59,7 @@ export const ToggleButton = forwardRef((props: ToggleButtonProps, ref) => {
             style={[
               styles.hstack,
               isActive && styles.active,
+              subtle && styles.subtle,
               isHovered && styles.hover,
               isPressed && styles.pressed,
               isFocusVisible && styles.focusVisible,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ const customColors = {
   black: "#000000",
   gray: {
     100: "#FDFDFD",
-    150: "#F2F2F2",
+    150: "#FAFAFC",
     200: "#EDEDF0",
     300: "#DCDDE5",
     400: "#CBCBD3",


### PR DESCRIPTION
Update styling and behaviour for comment-toggle in `PageHeader`

- adjust `ToggleButton` to have a more subtle variant
- improve `Tooltip` delay to not get into the way
- show _active_ `ToggleButton` when comments-sidebar is open

_additional_
- fix `PageHeaderLeft` editing-mode breakpoint
- add new-comment `Icon` variant
- add styling for new-comment logic (tbi)