### PR TITLE
UI empty states

### DIFF
--- a/apps/app/components/commentsSidebar/CommentsSidebar.tsx
+++ b/apps/app/components/commentsSidebar/CommentsSidebar.tsx
@@ -1,10 +1,9 @@
 import {
   VerticalDivider,
   EditorSidebarHeader,
-  Icon,
   Text,
   tw,
-  View,
+  EmptyMessage,
 } from "@serenity-tools/ui";
 import { useActor } from "@xstate/react";
 import { HStack } from "native-base";
@@ -40,15 +39,10 @@ const Header: React.FC = () => {
 
 const EmptyState: React.FC = () => {
   return (
-    <HStack space={3} style={tw`p-4`}>
-      <View style={tw``}>
-        <Icon name="chat-4-line-message" color={"gray-500"} size={5} />
-      </View>
-      <Text variant="xs" muted>
-        Add suggestions, questions or appreciations by marking a text-passage or
-        image and then clicking on the comment icon in the floating menu.
-      </Text>
-    </HStack>
+    <EmptyMessage iconName="chat-4-line-message">
+      Add suggestions, questions or appreciations by marking a text-passage or
+      image and then clicking on the comment icon in the floating menu.
+    </EmptyMessage>
   );
 };
 

--- a/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
+++ b/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
@@ -1256,6 +1256,7 @@ export default function DesignSystemScreen(
             <IconTile name="cup-line" />
             <IconTile name="question-mark" />
             <IconTile name="file-copy-line" />
+            <IconTile name="toc-line" />
             <IconTile name="chat-1-line" />
             <IconTile name="chat-1-line-message" />
             <IconTile name="chat-4-fill" />

--- a/packages/editor/components/tableOfContents/TableOfContents.tsx
+++ b/packages/editor/components/tableOfContents/TableOfContents.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableOfContentButton } from "@serenity-tools/ui";
+import { EmptyMessage, TableOfContentButton } from "@serenity-tools/ui";
 import { Editor } from "@tiptap/react";
 
 type Props = {
@@ -9,12 +9,17 @@ type Props = {
 export default function TableOfContents({ editor }: Props) {
   const content = editor?.getJSON().content || [];
 
+  let isEmpty = true;
+
   return (
     <>
       {content.map((entry, index) => {
         if (entry.type !== "heading") {
           return null;
         }
+
+        isEmpty = false;
+
         return (
           <TableOfContentButton lvl={entry.attrs?.level}>
             {entry.content?.map((subEntry, index) => {
@@ -26,6 +31,12 @@ export default function TableOfContents({ editor }: Props) {
           </TableOfContentButton>
         );
       })}
+      {isEmpty ? (
+        <EmptyMessage iconName={"toc-line"}>
+          Add Headers to structure your page and easily access certain parts of
+          your document.
+        </EmptyMessage>
+      ) : null}
     </>
   );
 }

--- a/packages/editor/components/tableOfContents/TableOfContents.tsx
+++ b/packages/editor/components/tableOfContents/TableOfContents.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { EmptyMessage, TableOfContentButton } from "@serenity-tools/ui";
+import { EmptyMessage, TableOfContentButton, tw } from "@serenity-tools/ui";
 import { Editor } from "@tiptap/react";
 
 type Props = {
@@ -32,7 +32,7 @@ export default function TableOfContents({ editor }: Props) {
         );
       })}
       {isEmpty ? (
-        <EmptyMessage iconName={"toc-line"}>
+        <EmptyMessage iconName={"toc-line"} style={tw`pt-0`}>
           Add Headers to structure your page and easily access certain parts of
           your document.
         </EmptyMessage>

--- a/packages/ui/components/emptyMessage/EmptyMessage.tsx
+++ b/packages/ui/components/emptyMessage/EmptyMessage.tsx
@@ -13,7 +13,7 @@ export const EmptyMessage = forwardRef((props: EmptyMessageProps, ref) => {
   const { iconName = "information-line" } = props;
 
   return (
-    <HStack space={3} style={tw`p-4`} {...props}>
+    <HStack {...props} space={3} style={[tw`p-4`, props.style]}>
       <View style={tw``}>
         <Icon name={iconName} color={"gray-500"} size={5} />
       </View>

--- a/packages/ui/components/emptyMessage/EmptyMessage.tsx
+++ b/packages/ui/components/emptyMessage/EmptyMessage.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from "react";
+import { HStack, IStackProps } from "native-base";
+import { tw } from "../../tailwind";
+import { View } from "../view/View";
+import { Icon, IconNames } from "../icon/Icon";
+import { Text } from "../text/Text";
+
+export type EmptyMessageProps = IStackProps & {
+  iconName?: IconNames;
+};
+
+export const EmptyMessage = forwardRef((props: EmptyMessageProps, ref) => {
+  const { iconName = "information-line" } = props;
+
+  return (
+    <HStack space={3} style={tw`p-4`} {...props}>
+      <View style={tw``}>
+        <Icon name={iconName} color={"gray-500"} size={5} />
+      </View>
+      <Text variant="xs" muted>
+        {props.children}
+      </Text>
+    </HStack>
+  );
+});

--- a/packages/ui/components/icon/Icon.tsx
+++ b/packages/ui/components/icon/Icon.tsx
@@ -114,6 +114,7 @@ import { StarSFill } from "./icons/StarSFill";
 import { Strikethrough } from "./icons/Strikethrough";
 import { Table2 } from "./icons/Table2";
 import { Text } from "./icons/Text";
+import { TOCLine } from "./icons/TOCLine";
 import { Underline } from "./icons/Underline";
 import { UserLine } from "./icons/UserLine";
 import { UserSettingsLine } from "./icons/UserSettingsLine";
@@ -239,6 +240,7 @@ export type IconNames =
   | "strikethrough"
   | "table-2"
   | "text"
+  | "toc-line"
   | "underline"
   | "user-line"
   | "user-settings-line"
@@ -604,6 +606,9 @@ export const Icon = (props: IconProps) => {
   }
   if (name === "text") {
     icon = <Text color={color} size={iconSize} />;
+  }
+  if (name === "toc-line") {
+    icon = <TOCLine color={color} size={iconSize} />;
   }
   if (name === "underline") {
     icon = <Underline color={color} size={iconSize} />;

--- a/packages/ui/components/icon/icons/TOCLine.tsx
+++ b/packages/ui/components/icon/icons/TOCLine.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+export type Props = { color: string; size: string };
+
+export const TOCLine = ({ color, size }: Props) => {
+  return (
+    <Svg height={size} width={size} viewBox="0 0 24 24">
+      <Path fill="none" d="M0 0h24v24H0z" />
+      <Path
+        fill={color}
+        fillRule={"evenodd"}
+        clipRule={"evenodd"}
+        d="M5 22H19C19.7956 22 20.5587 21.6839 21.1213 21.1213C21.6839 20.5587 22 19.7956 22 19V15H18V3C18 2.73478 17.8946 2.48043 17.7071 2.29289C17.5196 2.10536 17.2652 2 17 2H3C2.73478 2 2.48043 2.10536 2.29289 2.29289C2.10536 2.48043 2 2.73478 2 3V19C2 19.7956 2.31607 20.5587 2.87868 21.1213C3.44129 21.6839 4.20435 22 5 22ZM16.5 3.5V20.5H5C4.73478 20.5 4.24633 20.4019 3.91549 20.0833C3.56928 19.75 3.5 19.2652 3.5 19V3.5H16.5ZM14.5 6.5H8.5V8H14.5V6.5ZM7 6.5H5.5V8H7V6.5ZM18 16.5V19C18 20 18.8118 20.3848 19.3118 20.3848C19.8118 20.3848 20.5 20 20.5 19V16.5H18Z"
+      />
+      <Path fill={color} d="M11.5 10H8.5V11.5H11.5V10Z" />
+      <Path fill={color} d="M7 10H5.5V11.5H7V10Z" />
+    </Svg>
+  );
+};

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -14,6 +14,7 @@ export * from "./components/editorBottombarButton/EditorBottombarButton";
 export * from "./components/editorContentButton/EditorContentButton";
 export * from "./components/editorSidebarHeader/EditorSidebarHeader";
 export * from "./components/editorSidebarIcon/EditorSidebarIcon";
+export * from "./components/emptyMessage/EmptyMessage";
 export * from "./components/formWrapper/FormWrapper";
 export * from "./components/heading/Heading";
 export * from "./components/horizontalDivider/HorizontalDivider";


### PR DESCRIPTION
Handle empty states for `CommentsSidebar` and `TableOfContents`

- add new custom `Icon` for empty table-of-contents state
- add and use new `EmptyMessage` component
